### PR TITLE
Change the font family to `open-sans`

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Open_Sans } from "next/font/google";
 import "./globals.css";
 import ApolloClientProvider from "./ApolloClientProvider";
 import { CookiesProvider } from 'next-client-cookies/server';
+import { cn } from "@/lib/utils";
 
-const inter = Inter({ subsets: ["latin"] });
+const openSans = Open_Sans({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -20,7 +21,14 @@ export default function RootLayout({
     <html lang="en">
       <CookiesProvider>
         <ApolloClientProvider>
-          <body className={inter.className}>{children}</body>
+          <body
+            className={cn(
+              "min-h-screen bg-background font-sans antialiased",
+              openSans.variable
+            )}
+          >
+            {children}
+          </body>
         </ApolloClientProvider>
       </CookiesProvider>
     </html>


### PR DESCRIPTION
Import `open-sans` font family from `next/font/google` library and use it as the primary font family of the app 
instead of `Inter` font family.