### PR TITLE
Create `UserDataProvider` component and `useUserData` hook

### DIFF
--- a/src/app/UserDataProvider.tsx
+++ b/src/app/UserDataProvider.tsx
@@ -1,0 +1,39 @@
+"use client"
+import useGraphqlQuery from "@/lib/hooks/useGraphqlQuery";
+import { gql } from "@apollo/client";
+import { createContext } from "react";
+
+const USER_DATA_QUERY = gql`
+  query UserData {
+    userData {
+      firstName
+      lastName
+      headline
+      avatar
+      email
+      role
+      bookmarks
+    }
+  }
+`;
+
+type UserDataState = {
+  userData: User | null;
+  isLoading: boolean;
+  error?: Error;
+}
+
+export const UserDataContext = createContext<UserDataState>({ userData: null, isLoading: false });
+
+export default function UserDataProvider({ children }: React.PropsWithChildren) {
+
+  const userDataState = useGraphqlQuery<{ userData: User }>(USER_DATA_QUERY);
+
+  return (
+    <UserDataContext.Provider
+      value={{ ...userDataState, userData: userDataState.data?.userData || null }}
+    >
+      {children}
+    </UserDataContext.Provider>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import ApolloClientProvider from "./ApolloClientProvider";
 import { CookiesProvider } from 'next-client-cookies/server';
 import { cn } from "@/lib/utils";
+import UserDataProvider from "./UserDataProvider";
 
 const openSans = Open_Sans({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -21,14 +22,16 @@ export default function RootLayout({
     <html lang="en">
       <CookiesProvider>
         <ApolloClientProvider>
-          <body
-            className={cn(
-              "min-h-screen bg-background font-sans antialiased",
-              openSans.variable
-            )}
-          >
-            {children}
-          </body>
+          <UserDataProvider>
+            <body
+              className={cn(
+                "min-h-screen bg-background font-sans antialiased",
+                openSans.variable
+              )}
+            >
+              {children}
+            </body>
+          </UserDataProvider>
         </ApolloClientProvider>
       </CookiesProvider>
     </html>

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { UserDataContext } from "@/app/UserDataProvider";
+
+export default function useUserData() {
+  return useContext(UserDataContext);
+}


### PR DESCRIPTION
Create `UserDataProvider` component to wrapp the root layout with it
to share user data across the whole app for all client components.

Create `hooks` folder and create inside it `useUserData` hook to provide
a direct way to access user's data from user data context (`UserDataContext`).