### PR TITLE
Change the font family and add styles suites the new font family

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@100..900&display=swap");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -9,12 +10,14 @@
 
     --card: 20 14.3% 4.1%;
     --card-foreground: 60 9.1% 97.8%;
+    --card-hover: 20 19% 6%;
 
     --popover: 20 14.3% 4.1%;
     --popover-foreground: 60 9.1% 97.8%;
 
     --primary: 20.5 90.2% 48.2%;
     --primary-foreground: 60 9.1% 97.8%;
+    --primary-hover: 14 100% 57% / 15%;
 
     --secondary: 12 6.5% 15.1%;
     --secondary-foreground: 60 9.1% 97.8%;
@@ -69,8 +72,28 @@
 @layer base {
   * {
     @apply border-border;
+    font-family: "Noto Sans Arabic", sans-serif;
+    font-optical-sizing: auto;
+    font-style: normal;
+    font-variation-settings: "wdth" 100;
   }
   body {
     @apply bg-background text-foreground;
   }
+}
+
+.text-xs {
+  font-weight: 300;
+}
+
+.text-sm {
+  font-weight: 400;
+}
+
+.text-md {
+  font-weight: 600;
+}
+
+.text-lg {
+  font-weight: 900;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,8 @@
 import type { Metadata } from "next";
-import { Open_Sans } from "next/font/google";
 import "./globals.css";
 import ApolloClientProvider from "./ApolloClientProvider";
 import { CookiesProvider } from 'next-client-cookies/server';
-import { cn } from "@/lib/utils";
 import UserDataProvider from "./UserDataProvider";
-
-const openSans = Open_Sans({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -23,12 +19,7 @@ export default function RootLayout({
       <CookiesProvider>
         <ApolloClientProvider>
           <UserDataProvider>
-            <body
-              className={cn(
-                "min-h-screen bg-background font-sans antialiased",
-                openSans.variable
-              )}
-            >
+            <body className="min-h-screen bg-background antialiased">
               {children}
             </body>
           </UserDataProvider>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,13 +11,6 @@ const config = {
   ],
   prefix: "",
   theme: {
-    container: {
-      center: true,
-      padding: "2rem",
-      screens: {
-        "2xl": "1400px",
-      },
-    },
     extend: {
       colors: {
         border: "hsl(var(--border))",
@@ -28,6 +21,7 @@ const config = {
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
+          hover: "hsl(var(--primary-hover))",
         },
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
@@ -52,6 +46,7 @@ const config = {
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
+          hover: "hsl(var(--card-hover))",
         },
       },
       borderRadius: {


### PR DESCRIPTION
- Remove `Open Sans` font from the root layout

- Use `@import` in `globals.css` file to load `Noto Sans Arabic` font family.

- Apply the styles of the new font family `Noto Sans Arabic` to the all elements.

- Create different classes for the different font weights.