### PR TITLE
Add styles classes to the app layout elements and `globals.css` file

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -5,7 +5,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     return (
         <>
             <Header />
-            <main className="flex min-h-screen flex-col items-center justify-between">
+            <main className="flex flex-1 flex-col items-center justify-between">
                 <div className="flex flex-1 w-full">
                     <Sidebar />
                     {children}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,6 +77,14 @@
     font-style: normal;
     font-variation-settings: "wdth" 100;
   }
+  *::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+    background-color: hsl(var(--background));
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--muted));
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
       <CookiesProvider>
         <ApolloClientProvider>
           <UserDataProvider>
-            <body className="min-h-screen bg-background antialiased">
+            <body className="min-h-screen flex flex-col bg-background antialiased">
               {children}
             </body>
           </UserDataProvider>


### PR DESCRIPTION
- Add "flex" and "flex-col" classes to `body` element for making
its children flow vertically.

- Replace "min-h-screen" class from `main` element in `AppLayout`
component with "flex-1" class for making the `main` element takes
the height of its parent (the `body` element in `src/app/layout.tsx` file)
instead of specifying a height for it using "min-h-screen" class.

- Add styles to `globals.css` file to customize the scrollbars