### PR TITLE
Use `location.replace` object for navigating to home page from auth pages

### DIFF
--- a/src/hooks/useLogInFormLogic.ts
+++ b/src/hooks/useLogInFormLogic.ts
@@ -4,7 +4,6 @@ import useGraphqlMutation from "@/lib/hooks/useGraphqlMutation";
 import { gql } from "@apollo/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useCookies } from "next-client-cookies";
-import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -58,7 +57,6 @@ export default function useLogInFormLogic() {
   >();
 
   const cookies = useCookies();
-  const router = useRouter();
 
   async function onSubmit(userCredentials: z.infer<typeof formSchema>) {
     action({
@@ -66,7 +64,7 @@ export default function useLogInFormLogic() {
       query: LogInMutation,
       onSuccess: (res) => {
         if (res.logInUser?.accessToken) {
-          router.replace("/");
+          location.replace("/");
           cookies.set(accessTokenCookieName, res.logInUser.accessToken);
         }
       },

--- a/src/hooks/useSignUpFormLogic.ts
+++ b/src/hooks/useSignUpFormLogic.ts
@@ -3,7 +3,6 @@ import useGraphqlMutation from "@/lib/hooks/useGraphqlMutation";
 import { gql } from "@apollo/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useCookies } from "next-client-cookies";
-import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { logInRawShape } from "./useLogInFormLogic";
@@ -56,7 +55,6 @@ export default function useSignUpFormLogic() {
     SignUpActionResponse
   >();
 
-  const router = useRouter();
   const cookies = useCookies();
 
   async function onSubmit(userData: z.infer<typeof formSchema>) {
@@ -68,8 +66,8 @@ export default function useSignUpFormLogic() {
         variables: { newUser: userData },
         onSuccess: (res) => {
           if (res.signUpUser?.accessToken) {
-            router.replace("/");
             cookies.set(accessTokenCookieName, res.signUpUser.accessToken);
+            location.replace("/");
           }
         },
       });


### PR DESCRIPTION
Use `location.replace` instead of `useRouter` hook for navigating to the home page after successful log in or sign up because `location.replace` refreshes the page to user data be fetched from the server.