### PR TITLE
Make `useGraphqlQuery` hook provides update state option

### DIFF
--- a/src/lib/hooks/useGraphqlQuery.ts
+++ b/src/lib/hooks/useGraphqlQuery.ts
@@ -24,5 +24,5 @@ export default function useGraphqlQuery<T>(
       });
   }, []);
 
-  return { data, isLoading, error };
+  return { data, setData, isLoading, error };
 }


### PR DESCRIPTION
Make `useGraphqlQuery` hook provides `setData` function in its returned object to allow updating the fetched state data.