### PR TITLE
Add Loading state UI to login and signup pages & Fix error state variable

### DIFF
--- a/src/components/login-signup/LogInForm.tsx
+++ b/src/components/login-signup/LogInForm.tsx
@@ -16,13 +16,13 @@ import LoadingOverlay from "../LoadingOverlay"
 
 export default function LogInForm() {
 
-    const { form, onSubmit, state, isLoading } = useLogInFormLogic();
+    const { form, onSubmit, error, isLoading } = useLogInFormLogic();
 
     return (
         <FormCard
             title="تسجيل الدخول"
             description="أدخل معلومات حسابك الصحيحة لتسجيل دخولك"
-            errorMessage={state.error}
+            errorMessage={error}
         >
             <Form {...form}>
                 <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 mx-auto max-w-sm">

--- a/src/components/login-signup/LogInForm.tsx
+++ b/src/components/login-signup/LogInForm.tsx
@@ -12,10 +12,11 @@ import {
 import useLogInFormLogic from "@/hooks/useLogInFormLogic"
 import FormCard from "./FormCard"
 import Link from "next/link"
+import LoadingOverlay from "../LoadingOverlay"
 
 export default function LogInForm() {
 
-    const { form, onSubmit, state } = useLogInFormLogic();
+    const { form, onSubmit, state, isLoading } = useLogInFormLogic();
 
     return (
         <FormCard
@@ -63,6 +64,7 @@ export default function LogInForm() {
                     </Button>
                 </form>
             </Form>
+            {isLoading && <LoadingOverlay />}
         </FormCard>
     )
 }

--- a/src/components/login-signup/SignUpForm.tsx
+++ b/src/components/login-signup/SignUpForm.tsx
@@ -16,13 +16,13 @@ import LoadingOverlay from "../LoadingOverlay"
 
 export default function SignUpForm() {
 
-    const { form, onSubmit, state, isLoading } = useSignUpFormLogic()
+    const { form, onSubmit, error, isLoading } = useSignUpFormLogic();
 
     return (
         <FormCard
             title="إنشاء حساب"
             description="أدخل معلوماتك لإنشاء حساب جديد لك"
-            errorMessage={state.error}
+            errorMessage={error}
         >
             <Form {...form}>
                 <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 mx-auto max-w-sm">

--- a/src/components/login-signup/SignUpForm.tsx
+++ b/src/components/login-signup/SignUpForm.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/shadcn-ui/input"
 import useSignUpFormLogic from "@/hooks/useSignUpFormLogic"
 import FormCard from "./FormCard"
 import Link from "next/link"
+import LoadingOverlay from "../LoadingOverlay"
 
 export default function SignUpForm() {
 
@@ -124,10 +125,11 @@ export default function SignUpForm() {
                         type="submit"
                         className="w-full"
                     >
-                        {isLoading ? "جاري إنشاء حساب..." : "إنشاء حساب"}
+                        إنشاء حساب
                     </Button>
                 </form>
             </Form>
+            {isLoading && <LoadingOverlay />}
         </FormCard>
     )
 }

--- a/src/hooks/useLogInFormLogic.ts
+++ b/src/hooks/useLogInFormLogic.ts
@@ -51,7 +51,7 @@ export default function useLogInFormLogic() {
     },
   });
 
-  const { state, action, isLoading } = useGraphqlMutation<
+  const { state, error, action, isLoading } = useGraphqlMutation<
     z.infer<typeof formSchema>,
     LogInActionResponse
   >();
@@ -76,5 +76,6 @@ export default function useLogInFormLogic() {
     onSubmit,
     state,
     isLoading,
+    error,
   };
 }

--- a/src/hooks/useSignUpFormLogic.ts
+++ b/src/hooks/useSignUpFormLogic.ts
@@ -58,7 +58,7 @@ export default function useSignUpFormLogic() {
     },
   });
 
-  const { state, action, isLoading } = useGraphqlMutation<
+  const { state, error, action, isLoading } = useGraphqlMutation<
     SignUpMutationPayload,
     SignUpActionResponse
   >();
@@ -94,5 +94,6 @@ export default function useSignUpFormLogic() {
     onSubmit,
     isLoading,
     state,
+    error,
   };
 }


### PR DESCRIPTION
- Use `LoadingOverlay` component in log in and sign up pages
(`LogInForm` and `SignUpForm` components) to display
loading UI while loading state.

- Access `error` state from `useGraphqlMutation` hook in `useLogInFormLogic`
and `useSignUpFormLogic` hooks to return it si that `LogInForm` and
`SignUpForm` forms components can use it to display error messages.