### PR TITLE
Wrapp the root layout with `TooltipProvider` component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import ApolloClientProvider from "./ApolloClientProvider";
 import { CookiesProvider } from 'next-client-cookies/server';
 import UserDataProvider from "./UserDataProvider";
+import { TooltipProvider } from "@/components/shadcn-ui/tooltip";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -19,9 +20,11 @@ export default function RootLayout({
       <CookiesProvider>
         <ApolloClientProvider>
           <UserDataProvider>
-            <body className="min-h-screen flex flex-col bg-background antialiased">
-              {children}
-            </body>
+            <TooltipProvider>
+              <body className="min-h-screen flex flex-col bg-background antialiased">
+                {children}
+              </body>
+            </TooltipProvider>
           </UserDataProvider>
         </ApolloClientProvider>
       </CookiesProvider>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -2,7 +2,6 @@ import { ReactNode, RefAttributes } from 'react';
 import {
     Tooltip as TooltipContainer,
     TooltipContent,
-    TooltipProvider,
     TooltipTrigger
 } from './shadcn-ui/tooltip'
 import {
@@ -12,7 +11,7 @@ import {
     TooltipContentProps
 } from '@radix-ui/react-tooltip';
 
-interface TooltipProps {
+export interface TooltipProps {
     children: ReactNode;
     tooltipContent?: string;
     providerProps?: TooltipProviderProps;
@@ -25,21 +24,19 @@ export default function Tooltip({
     children,
     tooltipContent,
     triggerProps,
-    providerProps,
     containerProps,
     contentProps
 }: TooltipProps) {
 
-    return (!!tooltipContent ?
-        <TooltipProvider {...providerProps}>
-            <TooltipContainer delayDuration={200} {...containerProps}>
-                <TooltipTrigger {...triggerProps}>
-                    {children}
-                </TooltipTrigger>
-                <TooltipContent {...contentProps}>
-                    <p>{tooltipContent}</p>
-                </TooltipContent>
-            </TooltipContainer>
-        </TooltipProvider> : children
+    return (!
+        !tooltipContent ?
+        <TooltipContainer delayDuration={200} {...containerProps}>
+            <TooltipTrigger {...triggerProps}>
+                {children}
+            </TooltipTrigger>
+            <TooltipContent {...contentProps}>
+                <p>{tooltipContent}</p>
+            </TooltipContent>
+        </TooltipContainer> : children
     )
 }


### PR DESCRIPTION
Wrapp the root layout in `src/app/layout.tsx` with `TooltipProvider` component instead of using the `TooltipProvider` wrapper component in `Tooltip` component and `TooltipProvider` be reused whenever `Tooltip` component is used.