### PR TITLE
Convert `userFeeds` query response to pagination

### DIFF
--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -58,7 +58,12 @@ type PostComment = {
   downvotes: number;
 };
 
-type PaginationOptions = {
+type PaginationModel = {
   page: number;
   pageSize: number;
+};
+
+type UserFeedsResponse = {
+  posts: Post[];
+  areThereMore: boolean;
 };

--- a/src/graphql/UserFeedsQuery.tsx
+++ b/src/graphql/UserFeedsQuery.tsx
@@ -1,0 +1,43 @@
+import { gql } from "@apollo/client";
+
+export const defaultUserFeedsPaginationModel: PaginationModel = {
+  page: 1,
+  pageSize: 15,
+}
+export const getPostsQuery = gql`
+query UserFeeds($paginationOptions: PaginationOptions!) {
+  userFeeds(paginationOptions: $paginationOptions) {
+    posts {
+      id
+      title
+      publishedAt
+      category
+      authorId
+      upvotes
+      downvotes
+      userVote
+      author {
+        firstName
+        lastName
+        headline
+        avatar {
+          id
+          src
+        }
+      }
+      thumbnail {
+        src
+      }
+      tags
+      body
+      commentsCount
+      resources {
+        link
+        title
+        type
+      }
+    }
+    areThereMore
+  }
+}
+`;

--- a/src/lib/getHomePagePosts.ts
+++ b/src/lib/getHomePagePosts.ts
@@ -1,9 +1,14 @@
 import graphglQueryAction from "@/graphql/graphglQueryAction";
-import { getPostsQuery } from "../graphql/UserFeedsQuery";
+import {
+  defaultUserFeedsPaginationModel,
+  getPostsQuery,
+} from "../graphql/UserFeedsQuery";
 
 export default async function getHomePagePosts() {
   "use server";
-
-  const res = await graphglQueryAction<{ userFeeds: Post[] }>(getPostsQuery);
+  const res = await graphglQueryAction<{ userFeeds: UserFeedsResponse }>(
+    getPostsQuery,
+    { paginationOptions: defaultUserFeedsPaginationModel }
+  );
   return res.data.userFeeds;
 }

--- a/src/lib/getHomePagePosts.ts
+++ b/src/lib/getHomePagePosts.ts
@@ -1,40 +1,5 @@
 import graphglQueryAction from "@/graphql/graphglQueryAction";
-import { gql } from "@apollo/client";
-
-const getPostsQuery = gql`
-  query UserFeeds {
-    userFeeds {
-      id
-      title
-      publishedAt
-      category
-      authorId
-      upvotes
-      downvotes
-      userVote
-      author {
-        firstName
-        lastName
-        headline
-        avatar {
-          id
-          src
-        }
-      }
-      thumbnail {
-        src
-      }
-      tags
-      body
-      commentsCount
-      resources {
-        link
-        title
-        type
-      }
-    }
-  }
-`;
+import { getPostsQuery } from "../graphql/UserFeedsQuery";
 
 export default async function getHomePagePosts() {
   "use server";


### PR DESCRIPTION
- Create the new shape of user feeds response (`UserFeedsResponse`
type).

- Rename `PaginationOptions` type to `PaginationModel`.

- Create `src/graphql/UserFeedsQuery.tsx` file and move `userFeeds`
query from `src/lib/getHomePagePosts.ts` action file into it, And
create `defaultUserFeedsPaginationModel` variable inside this file.

- Change the response type of `userFeeds` query from `Post[]` to
`UserFeedsResponse` in `getHomePagePosts` server action.

- Include the default pagination model to user feeds query
via `paginationOptions` property of variables parameter
of `graphglQueryAction` function.