### PR TITLE
Add `ActionIcon` and `action` props to `Alert` component

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,4 +1,4 @@
-import { AlertOctagonIcon, CircleCheckBigIcon, InfoIcon, RefreshCwIcon, TriangleAlertIcon } from 'lucide-react'
+import { AlertOctagonIcon, CircleCheckBigIcon, InfoIcon, LucideIcon, RefreshCwIcon, TriangleAlertIcon } from 'lucide-react'
 import { cn } from '@/lib/utils';
 
 const alertVarians = {
@@ -32,17 +32,26 @@ type AlertProps = {
     message: string;
     title?: string;
     className?: string;
+    action?: () => void;
+    ActionIcon?: LucideIcon;
     variant: keyof typeof alertVarians
 }
 
-export default function Alert({ title, message, className, variant }: AlertProps) {
+export default function Alert({ title, message, action, ActionIcon, className, variant }: AlertProps) {
 
     const chosenVariant = alertVarians[variant]
     const ChosenIcon = alertVarians[variant].Icon
 
     return (
         <div className={cn('p-3 col-span-full border rounded-md', chosenVariant.borderColor, className)}>
-            <RefreshCwIcon className={`float-end size-[18px] cursor-pointer ${chosenVariant.textColor}`} />
+            {
+                action && ActionIcon &&
+                <ActionIcon
+                    size={18}
+                    className={`float-end cursor-pointer ${chosenVariant.textColor}`}
+                    onClick={action}
+                />
+            }
             <ChosenIcon className={`inline size-4 me-2 mb-1 tex ${chosenVariant.textColor}`} strokeWidth={3} />
             <h5 className={`${chosenVariant.textColor} text-md inline-block`}>
                 {title ? title : chosenVariant.title}


### PR DESCRIPTION
Add `ActionIcon` and `action` props to `Alert` component as optional props and make them depends on each other so that action icon ( `ActionIcon` prop) will appears only if `action` prop was passed and action function (`action` prop) will be triggered only by action icon.