### PR TITLE
Customize error message of home page posts feeds for users

### DIFF
--- a/src/components/hompage/HomePagePostsGridError.tsx
+++ b/src/components/hompage/HomePagePostsGridError.tsx
@@ -1,8 +1,11 @@
 "use client"
 import { AlertOctagonIcon } from "lucide-react";
 import PageMessage from "../PageMessage";
+import useUserData from "@/hooks/useUserData";
 
 export default function HomePagePostsGridError() {
+
+    const { userData } = useUserData()
 
     return (
         <div className="w-full h-full">
@@ -10,7 +13,7 @@ export default function HomePagePostsGridError() {
                 action={() => { location.reload() }}
                 actionMessage="إعادة المحاولة"
                 message="فشل جلب المنشورات"
-                descreption="خطأ غير متوقع اثناء محاولة جلب المنشورات المخصصة لك"
+                descreption={`خطأ غير متوقع اثناء محاولة جلب المنشورات ${userData ? "المخصصة لك" : ""}`}
                 Icon={AlertOctagonIcon}
             />
         </div>


### PR DESCRIPTION
in `HomePagePostsGridError` component, Use `useUserData` hook to check if the user is registered or not, and based on if he registered or not display different error message.