### PR TITLE
Set up `sonner`'s toaster for use

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 import ApolloClientProvider from "./ApolloClientProvider";
 import { CookiesProvider } from 'next-client-cookies/server';
-import UserDataProvider from "./UserDataProvider";
+import UserDataProvider from "../contexts/UserDataProvider";
+import { Toaster as SonnerToaster } from "sonner";
 import { TooltipProvider } from "@/components/shadcn-ui/tooltip";
 
 export const metadata: Metadata = {
@@ -23,6 +24,7 @@ export default function RootLayout({
             <TooltipProvider>
               <body className="min-h-screen flex flex-col bg-background antialiased">
                 {children}
+                <SonnerToaster theme="dark" />
               </body>
             </TooltipProvider>
           </UserDataProvider>

--- a/src/hooks/useSonnerToast.tsx
+++ b/src/hooks/useSonnerToast.tsx
@@ -1,0 +1,24 @@
+import { variantsColors, VariantsIcons } from "@/constants/feedbackVariants";
+import { toast } from "sonner";
+
+type SonnerToastProps = {
+  title: string,
+  description: string,
+  variant: FeedbackVariants,
+}
+
+export default function useSonnerToast() {
+  return ({ title, variant, description }: SonnerToastProps) => {
+    const Icon = VariantsIcons[variant]
+    toast(
+      <div className="space-y-2">
+        <div className="flex gap-2 items-center">
+          <Icon className="size-4" />
+          <p className="text-md">{title}</p>
+        </div>
+        <p className="text-sm block">{description}</p>
+      </div>,
+      { className: variantsColors[variant].background }
+    );
+  }
+}


### PR DESCRIPTION
- Add the container of `sonner` toaster (`SonnerToaster` component)
to the layout component.

- Create `useSonnerToast` hook that uses `toast` function of
`sonner` library to display custom toasts.