### PR TITLE
Build post card and full post card dialog

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { CookiesProvider } from 'next-client-cookies/server';
 import UserDataProvider from "../contexts/UserDataProvider";
 import { Toaster as SonnerToaster } from "sonner";
 import { TooltipProvider } from "@/components/shadcn-ui/tooltip";
+import PostFullCardDialogProvider from "@/contexts/PostFullCardDialogProvider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -23,8 +24,10 @@ export default function RootLayout({
           <UserDataProvider>
             <TooltipProvider>
               <body className="min-h-screen flex flex-col bg-background antialiased">
-                {children}
-                <SonnerToaster theme="dark" />
+                <PostFullCardDialogProvider>
+                  {children}
+                  <SonnerToaster theme="dark" />
+                </PostFullCardDialogProvider>
               </body>
             </TooltipProvider>
           </UserDataProvider>

--- a/src/components/post-card/PostCard.tsx
+++ b/src/components/post-card/PostCard.tsx
@@ -1,0 +1,59 @@
+"use client"
+import Image from "next/image"
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../shadcn-ui/card"
+import PostBookmark from "./PostBookmark"
+import PostVotes from "./PostVotes"
+import PostTagsDisplayer from "./PostTagsDisplayer"
+import PostPublishDate from "./PostPublishDate"
+import PostResources from "./PostResources"
+import PostCommentsIcon from "../post-comments-section/PostCommentsIcon"
+import PostCategoryMark from "./PostCategoryMark"
+import usePostFullCardDialog from "@/hooks/usePostFullCardDialog"
+
+interface PostCardProps {
+    post: Post
+}
+
+export default function PostCard({ post }: PostCardProps) {
+
+    const { open } = usePostFullCardDialog();
+
+    function openPostFullCard(scrollToCommentsSection?: boolean) {
+        open(post, scrollToCommentsSection)
+    }
+
+    return (
+        <Card
+            className="flex group flex-col transition-colors hover:bg-card-hover cursor-pointer"
+            onClick={() => { openPostFullCard() }}
+        >
+            <CardHeader className="p-3 pb-0">
+                <Image
+                    alt={post.title}
+                    src={post.thumbnail.src}
+                    width={200}
+                    height={120}
+                    className="w-full md:h-40"
+                />
+            </CardHeader>
+            <CardContent className="p-3 pb-0 flex flex-col gap-2 flex-1">
+                <CardTitle className="text-xl flex-1">{post.title}</CardTitle>
+                <PostTagsDisplayer tags={post.tags} />
+                <PostPublishDate publishDate={post.publishedAt} />
+            </CardContent>
+            <PostCategoryMark category={post.category} />
+            <CardFooter className="gap-2 p-3">
+                <PostCommentsIcon
+                    commentsCount={post.commentsCount}
+                    openPostFullCard={openPostFullCard}
+                />
+                <PostBookmark postId={post.id} />
+                <PostResources resources={post.resources} />
+                <PostVotes
+                    post={post}
+                    containerClassName="flex-1"
+                />
+            </CardFooter>
+        </Card>
+    )
+}

--- a/src/components/post-comments-section/PostCommentsIcon.tsx
+++ b/src/components/post-comments-section/PostCommentsIcon.tsx
@@ -1,19 +1,17 @@
 import { MessageSquareText } from 'lucide-react'
 import convertToArabic from '@/lib/convertToArabic'
 import PostCardIconButton from '../post-card/PostCardIconButton'
-import { Dispatch, MouseEvent, SetStateAction } from 'react'
+import { MouseEvent } from 'react'
 
 type PostCommentsIconProps = {
     commentsCount: number;
-    scrollToCommentsSectionState: [boolean, Dispatch<SetStateAction<boolean>>]
+    openPostFullCard(scrollToCommentsSection?: boolean): void
 }
 
-export default function PostCommentsIcon({ commentsCount, scrollToCommentsSectionState }: PostCommentsIconProps) {
-
-    const [scrollToCommentsSection, setScrollToCommentsSection] = scrollToCommentsSectionState
+export default function PostCommentsIcon({ commentsCount, openPostFullCard }: PostCommentsIconProps) {
 
     function handleClick(_e: MouseEvent<HTMLButtonElement>) {
-        !scrollToCommentsSection && setScrollToCommentsSection(true)
+        openPostFullCard(true)
     }
 
     return (
@@ -21,7 +19,6 @@ export default function PostCommentsIcon({ commentsCount, scrollToCommentsSectio
             tooltipContent="التعليقات"
             className='hover:!bg-blue-600/30'
             onClick={handleClick}
-            dontStopPropagation
         >
             <MessageSquareText size={20} />
             {convertToArabic(commentsCount)}

--- a/src/contexts/PostFullCardDialogProvider.tsx
+++ b/src/contexts/PostFullCardDialogProvider.tsx
@@ -1,0 +1,111 @@
+"use client"
+import PostAuthor from "@/components/post-card/PostAuthor";
+import PostBookmark from "@/components/post-card/PostBookmark";
+import PostPublishDate from "@/components/post-card/PostPublishDate";
+import PostResourcesList from "@/components/post-card/PostResourcesList";
+import PostTagsDisplayer from "@/components/post-card/PostTagsDisplayer";
+import PostVotes from "@/components/post-card/PostVotes";
+import PostCommentsSection from "@/components/post-comments-section/PostCommentsSection";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/shadcn-ui/dialog";
+import { LinkIcon } from "lucide-react";
+import Image from "next/image";
+import {
+  createContext,
+  PropsWithChildren,
+  useState
+} from "react";
+
+type PostFullCardProviderValue = {
+  open: (post: Post, scrollToCommentsSection?: boolean) => void;
+}
+
+export const PostFullCardDialogContext = createContext<PostFullCardProviderValue>({
+  open(_post, _scrollToCommentsSection) { },
+});
+
+export default function PostFullCardDialogProvider({ children }: PropsWithChildren) {
+
+  const [post, setPost] = useState<Post>();
+  const [isOpen, setIsOpen] = useState(false);
+  const [scrollToCommentsSection, setScrollToCommentsSection] = useState(false);
+
+  function open(post: Post, scrollToCommentsSection?: boolean) {
+    setIsOpen(!!post);
+    setPost(post);
+    setScrollToCommentsSection(!!scrollToCommentsSection);
+  }
+
+  function close() {
+    setIsOpen(false);
+    setPost(undefined);
+    setScrollToCommentsSection(false)
+  }
+
+  return (
+    <PostFullCardDialogContext.Provider value={{ open }}>
+      {children}
+      {
+        isOpen && post &&
+        <Dialog open>
+          <DialogContent
+            onOverlayClick={close}
+            onClose={close}
+            className="max-h-[700px] sm:min-w-[600px] overflow-y-auto p-4"
+            ref={(elem) => {
+              if (scrollToCommentsSection) {
+                elem?.scrollBy({ top: elem?.clientHeight })
+              }
+            }}
+          >
+            <DialogHeader className="gap-2">
+              <Image
+                src={post.thumbnail.src}
+                alt="Post thumbnail"
+                width={600}
+                height={400}
+              />
+              <DialogTitle className="text-2xl">{post.title}</DialogTitle>
+              <DialogDescription className="text-md">
+                {post.body}
+              </DialogDescription>
+              <PostPublishDate
+                className="text-md"
+                publishDate={post.publishedAt}
+                displayFullDate
+              />
+            </DialogHeader>
+            <PostTagsDisplayer tags={post.tags} displayAllTags />
+
+            <PostAuthor author={post.author} />
+
+            <div className="flex items-center justify-between py-4">
+              <PostVotes post={post} />
+              <PostBookmark postId={post.id} />
+            </div>
+
+            <h3 className="text-lg mt-3 flex gap-2 items-center">
+              <LinkIcon size={19} />
+              المصادر
+            </h3>
+            <PostResourcesList resources={post.resources} />
+
+            <h3 className="text-lg mt-3">
+              التعليقات
+              <span className="ms-2">( {post.commentsCount} )</span>
+            </h3>
+            <PostCommentsSection
+              postId={post.id}
+              postCommentsCount={post.commentsCount}
+            />
+          </DialogContent>
+        </Dialog>
+      }
+    </PostFullCardDialogContext.Provider >
+  )
+}

--- a/src/hooks/usePostFullCardDialog.ts
+++ b/src/hooks/usePostFullCardDialog.ts
@@ -1,0 +1,6 @@
+import { PostFullCardDialogContext } from "@/contexts/PostFullCardDialogProvider";
+import { useContext } from "react";
+
+export default function usePostFullCardDialog() {
+  return useContext(PostFullCardDialogContext);
+}


### PR DESCRIPTION
- Create `PostFullCardDialogProvider` component which
contains the full post card dialog and provides an object
with `open` method that is used to open the full post card
dialog for a specific post.

- Wrapp the content of the body element in `src/app/layout.tsx` file with
`PostFullCardDialogProvider` component.

- Create `usePostFullCardDialog` hook to provide an easier
way to access the context of post full card dialog (specificly
`open` method that is used to open a full card dialog for
a specific post).


- Add `openPostFullCard` prop to `PostCommentsIcon` component,
which is a function for calling it with `true` as the 1st parameter for
opening the full card dialog of the post and scrolling to comments
section.
Remove `scrollToCommentsSectionState` prop from `PostCommentsIcon`
component because it will not be used anymore.
Remove `dontStopPropagation` option from `PostCardIconButton`
inside `PostCommentsIcon` component because it will make an
unwanted effect after `scrollToCommentsSectionState` prop has
removed.


- Use the components that were created before in `src/components/post-card`
folder to build `PostCard` component, which is the final shape that
posts will be represented with in the UI.

- Use `usePostFullCardDialog` hook in `PostCard` component to open
the full details (full post card dialog ) of the post.