### PR TITLE
Change the API of removing comments from a post

### DIFF
--- a/src/contexts/PostCommentsProvider.tsx
+++ b/src/contexts/PostCommentsProvider.tsx
@@ -8,7 +8,7 @@ type PostCommentsContextType = {
     isLoading: boolean,
     error?: string,
     addComment: (comment: PostComment) => void;
-    removeComment: (select: (post: PostComment) => boolean) => void;
+    removeComment: (commentId: PostComment["id"]) => void;
     loadMoreComments: () => void;
     paginationModel: PaginationModel
 }

--- a/src/hooks/usePostCommentsPagination.ts
+++ b/src/hooks/usePostCommentsPagination.ts
@@ -40,7 +40,7 @@ export default function usePostCommentsPagination({
     loadMore: loadMoreComments,
     paginationModel,
     addData: addComment,
-    removeData: removeComment,
+    removeData,
     areThereMoreData: areThereMoreComments,
   } = usePagination<PostComment, "getPostComments", "comments">({
     Query: getPostCommentsQuery,
@@ -55,6 +55,10 @@ export default function usePostCommentsPagination({
       areThereMoreData: !!postCommentsCount,
     },
   });
+
+  function removeComment(commentId: PostComment["id"]) {
+    removeData((comment) => comment.id === commentId);
+  }
 
   return {
     comments,


### PR DESCRIPTION
Create `removeComment` function and make uses `removeData` function of `usePagination` hook to handles selecting the comment to delete it and provides an easier API (just pass comment id).