### PR TITLE
Display author's avatar in `PostAuthor` component

### DIFF
--- a/src/components/post-card/PostAuthor.tsx
+++ b/src/components/post-card/PostAuthor.tsx
@@ -3,7 +3,10 @@ import Avatar from '../Avatar'
 export default function PostAuthor({ author }: { author: Post["author"] }) {
     return (
         <div className="flex items-center gap-2 py-2">
-            <Avatar fallback='AC' />
+            <Avatar
+                src={author.avatar?.src}
+                fallback={author.firstName[0] + author.lastName[0]}
+            />
             <div className="me-5">
                 <p className="text-md">{author.firstName} {author.lastName}</p>
                 <p className="text-ms text-muted-foreground">{author.headline}</p>


### PR DESCRIPTION
Pass the url of author's avatar to `src` prop of `Avatar` component in `PostAuthor` component.