### PR TITLE
Separate validation schemas of authentication forms

### DIFF
--- a/src/hooks/useLogInFormLogic.ts
+++ b/src/hooks/useLogInFormLogic.ts
@@ -1,29 +1,11 @@
 import accessTokenCookieName from "@/constants/accessTokenCookieName";
-import convertToArabic from "@/lib/convertToArabic";
 import useGraphqlMutation from "@/hooks/useGraphqlMutation";
 import { gql } from "@apollo/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useCookies } from "next-client-cookies";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-
-export const logInRawShape: { email: z.ZodString; password: z.ZodString } = {
-  email: z
-    .string({ message: "يجب ان تدخل بريداً إلكترونياً" })
-    .min(
-      6,
-      `البريد الإلكتروني يجب ان يتكون من ${convertToArabic(6)} احرف على الأقل`
-    )
-    .max(
-      100,
-      `البريد الإلكتروني يجب ان لايتخطى ال ${convertToArabic(100)} حرف`
-    ),
-
-  password: z
-    .string({ message: "يجب ان تتكون كلمة المرور من حروف وأرقام" })
-    .min(8, `يجب ان تتكون كلمة المرور من ${convertToArabic(8)} حروف على الأقل`)
-    .max(150, `كلمة المرور يجب ان لا تتجاوز ال ${convertToArabic(150)} حرف`),
-};
+import logInRawShape from "@/validation/logInFormValidation";
 
 const formSchema = z.object(logInRawShape);
 

--- a/src/hooks/useSignUpFormLogic.ts
+++ b/src/hooks/useSignUpFormLogic.ts
@@ -5,35 +5,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useCookies } from "next-client-cookies";
 import { ControllerRenderProps, useForm, UseFormReturn } from "react-hook-form";
 import { z } from "zod";
-import { logInRawShape } from "./useLogInFormLogic";
-import convertToArabic from "@/lib/convertToArabic";
 import useImagesCloud from "./useImageUploader";
-import {
-  invalidImageTypeMessage,
-  tooLargeImageMessage,
-  validateImageFileSize,
-  validateImageFileType,
-} from "@/utils/imageFileValidation";
-
-const namesRole = (fieldName: string) => {
-  return z
-    .string({ message: `يجب ان تكتب ${fieldName} هنا` })
-    .min(3, `${fieldName} يجب ان يتكون من ${convertToArabic(3)} احرف على الأقل`)
-    .max(50, `${fieldName} يجب ان لا يتخطى ال ${convertToArabic(50)} حرف`);
-};
-
-const formSchema = z.object({
-  firstName: namesRole("الإسم الأول"),
-  lastName: namesRole("الإسم الأخير"),
-  headline: namesRole("العنوان الرئيسي او التخصص"),
-  avatar: z
-    .instanceof(File)
-    .refine(validateImageFileType, invalidImageTypeMessage)
-    .refine(validateImageFileSize, tooLargeImageMessage)
-    .optional(),
-  ...logInRawShape,
-  password2: logInRawShape.password,
-});
+import signUpFormSchema from "@/validation/signUpFormValidation";
 
 const SignUpMutation = gql`
   mutation SignUp($newUser: SignUpUserInput!) {
@@ -50,7 +23,7 @@ type SignUpActionResponse = {
   error?: string;
 };
 
-type SignUpFormSchemaType = z.infer<typeof formSchema>;
+type SignUpFormSchemaType = z.infer<typeof signUpFormSchema>;
 export type SignUpFormType = UseFormReturn<SignUpFormSchemaType>;
 
 export type SignUpFormFieldType<field extends keyof SignUpFormSchemaType> =
@@ -67,7 +40,7 @@ type SignUpMutationPayload = {
 
 export default function useSignUpFormLogic() {
   const form = useForm<SignUpFormSchemaType>({
-    resolver: zodResolver(formSchema),
+    resolver: zodResolver(signUpFormSchema),
     defaultValues: {
       firstName: "",
       lastName: "",

--- a/src/validation/logInFormValidation.ts
+++ b/src/validation/logInFormValidation.ts
@@ -1,0 +1,22 @@
+import convertToArabic from "@/lib/convertToArabic";
+import { z } from "zod";
+
+export const logInFormSchema: { email: z.ZodString; password: z.ZodString } = {
+  email: z
+    .string({ message: "يجب ان تدخل بريداً إلكترونياً" })
+    .min(
+      6,
+      `البريد الإلكتروني يجب ان يتكون من ${convertToArabic(6)} احرف على الأقل`
+    )
+    .max(
+      100,
+      `البريد الإلكتروني يجب ان لايتخطى ال ${convertToArabic(100)} حرف`
+    ),
+
+  password: z
+    .string({ message: "يجب ان تتكون كلمة المرور من حروف وأرقام" })
+    .min(8, `يجب ان تتكون كلمة المرور من ${convertToArabic(8)} حروف على الأقل`)
+    .max(150, `كلمة المرور يجب ان لا تتجاوز ال ${convertToArabic(150)} حرف`),
+};
+
+export default logInFormSchema;

--- a/src/validation/signUpFormValidation.ts
+++ b/src/validation/signUpFormValidation.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import logInRawShape from "./logInFormValidation";
+import {
+  invalidImageTypeMessage,
+  tooLargeImageMessage,
+  validateImageFileSize,
+  validateImageFileType,
+} from "@/utils/imageFileValidation";
+import convertToArabic from "@/lib/convertToArabic";
+
+const namesRole = (fieldName: string) => {
+  return z
+    .string({ message: `يجب ان تكتب ${fieldName} هنا` })
+    .min(3, `${fieldName} يجب ان يتكون من ${convertToArabic(3)} احرف على الأقل`)
+    .max(50, `${fieldName} يجب ان لا يتخطى ال ${convertToArabic(50)} حرف`);
+};
+
+const signUpFormSchema = z.object({
+  firstName: namesRole("الإسم الأول"),
+  lastName: namesRole("الإسم الأخير"),
+  headline: namesRole("العنوان الرئيسي او التخصص"),
+  avatar: z
+    .instanceof(File)
+    .refine(validateImageFileType, invalidImageTypeMessage)
+    .refine(validateImageFileSize, tooLargeImageMessage)
+    .optional(),
+  ...logInRawShape,
+  password2: logInRawShape.password,
+});
+
+export default signUpFormSchema;


### PR DESCRIPTION
* Create `src/validation` folder and `logInFormValidation.ts` file
inside this folder, And Separate the log in form schema
(`logInFormSchema`) from `useLogInFormLogic` hook into this file.

* Create `logInFormValidation.ts` file in `src/validation` folder,
And Separate sign up form schema (`signUpFormSchema`)
from `useSignUpFormLogic` hook into this file.